### PR TITLE
Add schema validation tests with sample events

### DIFF
--- a/eventSchema.json
+++ b/eventSchema.json
@@ -1,78 +1,72 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://example.com/schemas/transaction-event.schema.json",
   "title": "Bank-Transaction Event",
-  "description": "Canonical log record ingested by the Shadow Risk-Scoring service.",
   "type": "object",
   "additionalProperties": false,
-
   "properties": {
-    "event_id":      { "type": "string",  "description": "ULID/UUID v4, immutable" },
-    "event_time":    { "type": "string",  "format": "date-time", "description": "ISO-8601 in UTC" },
-    "event_type":    { "type": "string",  "enum": ["transaction"], "default": "transaction" },
-    "schema_version":{ "type": "string",  "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$" },
-
+    "event_id": { "type": "string" },
+    "event_time": { "type": "string", "format": "date-time" },
+    "event_type": { "type": "string", "enum": ["transaction"], "default": "transaction" },
+    "schema_version": { "type": "string", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$" },
+    "transaction": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
         "transaction_id": { "type": "string" },
-        "account_id":     { "type": "string", "description": "Internal customer/account identifier (hashed or tokenised)" },
-        "timestamp":      { "type": "string", "format": "date-time" },
-        "amount":         { "type": "number", "minimum": 0 },
-        "currency":       { "type": "string", "pattern": "^[A-Z]{3}$" },
+        "account_id": { "type": "string" },
+        "timestamp": { "type": "string", "format": "date-time" },
+        "amount": { "type": "number", "minimum": 0 },
+        "currency": { "type": "string", "pattern": "^[A-Z]{3}$" },
         "merchant": {
           "type": "object",
           "additionalProperties": false,
           "properties": {
-            "mcc":        { "type": "string", "pattern": "^[0-9]{4}$" },
-            "merchant_id":{ "type": "string" },
-            "name":       { "type": "string" }
+            "mcc": { "type": "string", "pattern": "^[0-9]{4}$" },
+            "merchant_id": { "type": "string" },
+            "name": { "type": "string" }
           },
           "required": ["mcc"]
         },
-        "channel":       { "type": "string", "enum": ["ecom", "pos", "atm", "mobile", "web"] },
-        "status":        { "type": "string", "enum": ["authorised", "declined", "reversed", "pending"] }
+        "channel": { "type": "string", "enum": ["ecom", "pos", "atm", "mobile", "web"] },
+        "status": { "type": "string", "enum": ["authorised", "declined", "reversed", "pending"] }
       },
       "required": ["transaction_id", "account_id", "timestamp", "amount", "currency", "status"]
     },
-
     "device": {
+      "type": "object",
       "additionalProperties": false,
       "properties": {
-        "device_id":    { "type": "string" },
-        "ip_address":   { "type": "string", "format": "ipv4" },
-        "user_agent":   { "type": "string" },
-        "fingerprint":  { "type": "string", "description": "Browser/device fingerprint hash" }
+        "device_id": { "type": "string" },
+        "ip_address": { "type": "string", "format": "ipv4" },
+        "user_agent": { "type": "string" },
+        "fingerprint": { "type": "string" }
       }
     },
-
     "location": {
       "type": "object",
       "properties": {
-        "lat":         { "type": "number", "minimum": -90, "maximum": 90 },
-        "lon":         { "type": "number", "minimum": -180, "maximum": 180 },
+        "lat": { "type": "number", "minimum": -90, "maximum": 90 },
+        "lon": { "type": "number", "minimum": -180, "maximum": 180 },
         "country_iso": { "type": "string", "pattern": "^[A-Z]{2}$" },
-        "region":      { "type": "string" },
-        "city":        { "type": "string" }
+        "region": { "type": "string" },
+        "city": { "type": "string" }
       }
     },
-
     "features": {
       "type": "object",
       "additionalProperties": false,
-        "is_high_risk_country":   { "type": "boolean" },
-        "minutes_since_last_tx":  { "type": "integer", "minimum": 0 },
-        "velocity_score":         { "type": "number",  "minimum": 0, "maximum": 1 },
-        "historical_avg_amount":  { "type": "number",  "minimum": 0 }
+      "properties": {
+        "is_high_risk_country": { "type": "boolean" },
+        "minutes_since_last_tx": { "type": "integer", "minimum": 0 },
+        "velocity_score": { "type": "number", "minimum": 0, "maximum": 1 },
+        "historical_avg_amount": { "type": "number", "minimum": 0 }
       }
     },
-
-    
-    "pii_redacted":  { "type": "boolean", "default": false },
+    "pii_redacted": { "type": "boolean", "default": false },
     "consent_flags": {
       "type": "array",
       "items": { "type": "string" }
+    }
   },
-
   "required": ["event_id", "event_time", "transaction"]
 }

--- a/schemaValidityTest.py
+++ b/schemaValidityTest.py
@@ -1,11 +1,19 @@
 from pathlib import Path
-import json, jsonschema, pytest
+import json
+import jsonschema
+import pytest
 
 SCHEMA = json.loads(Path("eventSchema.json").read_text())
+DATA_DIR = Path("tests/data")
 
-@pytest.fixture()
-def example():
-    return json.loads(Path("eventSchema.json").read_text())
+def _load_events(pattern: str):
+    return [json.loads(path.read_text()) for path in DATA_DIR.glob(pattern)]
 
-def test_valid_event(example):
-    jsonschema.validate(example, SCHEMA)
+@pytest.mark.parametrize("event", _load_events("valid*.json"))
+def test_valid_events(event):
+    jsonschema.validate(instance=event, schema=SCHEMA)
+
+@pytest.mark.parametrize("event", _load_events("invalid*.json"))
+def test_invalid_events(event):
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=event, schema=SCHEMA)

--- a/tests/data/invalid_transaction_missing_field.json
+++ b/tests/data/invalid_transaction_missing_field.json
@@ -1,0 +1,11 @@
+{
+  "event_time": "2024-01-01T12:00:00Z",
+  "transaction": {
+    "transaction_id": "tx-2",
+    "account_id": "acc-2",
+    "timestamp": "2024-01-01T12:00:00Z",
+    "amount": -10.0,
+    "currency": "USD",
+    "status": "authorised"
+  }
+}

--- a/tests/data/valid_transaction.json
+++ b/tests/data/valid_transaction.json
@@ -1,0 +1,40 @@
+{
+  "event_id": "123e4567-e89b-12d3-a456-426614174000",
+  "event_time": "2024-01-01T12:00:00Z",
+  "event_type": "transaction",
+  "schema_version": "1.0.0",
+  "transaction": {
+    "transaction_id": "tx-1",
+    "account_id": "acc-1",
+    "timestamp": "2024-01-01T12:00:00Z",
+    "amount": 100.0,
+    "currency": "USD",
+    "merchant": {
+      "mcc": "1234",
+      "merchant_id": "m-1",
+      "name": "Test Merchant"
+    },
+    "channel": "web",
+    "status": "authorised"
+  },
+  "device": {
+    "device_id": "dev-1",
+    "ip_address": "192.168.0.1",
+    "user_agent": "Mozilla/5.0"
+  },
+  "location": {
+    "lat": 40.7128,
+    "lon": -74.0060,
+    "country_iso": "US",
+    "region": "NY",
+    "city": "New York"
+  },
+  "features": {
+    "is_high_risk_country": false,
+    "minutes_since_last_tx": 10,
+    "velocity_score": 0.1,
+    "historical_avg_amount": 50.0
+  },
+  "pii_redacted": false,
+  "consent_flags": ["test"]
+}


### PR DESCRIPTION
## Summary
- Replace malformed event schema with valid JSON Schema definition
- Add sample valid and invalid transaction event JSON files
- Validate sample events against schema and assert invalid events are rejected

## Testing
- `pytest schemaValidityTest.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689d7e387bb48322a9f00e864cac74b7