### PR TITLE
chore: sanitize public event schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 Work in progress
 -------------------------------
 ~The vision here is to build a severless platform that consumes logs and outputs a prediction pertaining to fraud.
+
+## Event Schema
+
+The public `eventSchema.json` describes the format of transaction events. Sensitive fraud-detection indicators (such as velocity metrics or historical averages) have been removed. The `features` object is intentionally generic; internal feature names remain private.

--- a/eventSchema.json
+++ b/eventSchema.json
@@ -12,6 +12,7 @@
     "event_type":    { "type": "string",  "enum": ["transaction"], "default": "transaction" },
     "schema_version":{ "type": "string",  "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$" },
 
+    "transaction": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
@@ -37,6 +38,7 @@
     },
 
     "device": {
+      "type": "object",
       "additionalProperties": false,
       "properties": {
         "device_id":    { "type": "string" },
@@ -48,6 +50,7 @@
 
     "location": {
       "type": "object",
+      "additionalProperties": false,
       "properties": {
         "lat":         { "type": "number", "minimum": -90, "maximum": 90 },
         "lon":         { "type": "number", "minimum": -180, "maximum": 180 },
@@ -59,19 +62,15 @@
 
     "features": {
       "type": "object",
-      "additionalProperties": false,
-        "is_high_risk_country":   { "type": "boolean" },
-        "minutes_since_last_tx":  { "type": "integer", "minimum": 0 },
-        "velocity_score":         { "type": "number",  "minimum": 0, "maximum": 1 },
-        "historical_avg_amount":  { "type": "number",  "minimum": 0 }
-      }
+      "description": "Derived features for risk assessment. Specific feature names are intentionally omitted.",
+      "additionalProperties": { "type": ["number", "string", "boolean"] }
     },
 
-    
     "pii_redacted":  { "type": "boolean", "default": false },
     "consent_flags": {
       "type": "array",
       "items": { "type": "string" }
+    }
   },
 
   "required": ["event_id", "event_time", "transaction"]

--- a/schemaValidityTest.py
+++ b/schemaValidityTest.py
@@ -1,11 +1,8 @@
 from pathlib import Path
-import json, jsonschema, pytest
+import json
+from jsonschema import Draft202012Validator
 
 SCHEMA = json.loads(Path("eventSchema.json").read_text())
 
-@pytest.fixture()
-def example():
-    return json.loads(Path("eventSchema.json").read_text())
-
-def test_valid_event(example):
-    jsonschema.validate(example, SCHEMA)
+def test_schema_is_valid():
+    Draft202012Validator.check_schema(SCHEMA)


### PR DESCRIPTION
## Summary
- remove internal risk scoring fields from `eventSchema.json`
- document that only a generic `features` map is exposed publicly
- validate JSON schema using Draft 2020-12 validator

## Testing
- `pytest -q schemaValidityTest.py`


------
https://chatgpt.com/codex/tasks/task_e_689d7e07fcf08322ab6d6ff099e6ffb6