### PR TITLE
chore: add weekly dependency audit workflow

### DIFF
--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -1,0 +1,21 @@
+name: Dependency Audit
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'
+  workflow_dispatch:
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install pip-audit
+        run: |
+          python -m pip install --upgrade pip
+          pip install pip-audit
+      - name: Run pip-audit
+        run: pip-audit -r requirements.txt


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run pip-audit weekly
- dependencies audited; no vulnerable packages found

## Testing
- `pytest -q`
- `pip-audit -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_689d7e24f01c83229a5dbbcf63f8c432