### PR TITLE
Add basic rule-based fraud detector with structured logging

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,4 @@
+[allowlist]
+  paths = [
+    ".venv/"
+  ]

--- a/README.md
+++ b/README.md
@@ -2,6 +2,18 @@ Work in progress
 -------------------------------
 ~The vision here is to build a severless platform that consumes logs and outputs a prediction pertaining to fraud.
 
+## Fraud detector
+
+A minimal rule-based detector is available in `fraud_detector.py`. The `evaluate_transaction`
+function returns a structured decision and emits JSON logs with a correlation ID to aid
+tracing.
+
+## Run tests
+
+```bash
+pytest
+```
+
 ## Security checks
 
 Run the same security scanners locally before committing changes:

--- a/fraud_detector.py
+++ b/fraud_detector.py
@@ -1,0 +1,44 @@
+import json
+import logging
+import uuid
+from typing import Dict, Any
+
+logger = logging.getLogger("fraud_detector")
+_handler = logging.StreamHandler()
+_handler.setFormatter(logging.Formatter('%(message)s'))
+logger.addHandler(_handler)
+logger.setLevel(logging.INFO)
+
+def _log(entry: Dict[str, Any], correlation_id: str) -> None:
+    log_record = {"correlation_id": correlation_id, **entry}
+    logger.info(json.dumps(log_record))
+
+def evaluate_transaction(event: Dict[str, Any], correlation_id: str | None = None) -> Dict[str, Any]:
+    """Return fraud decision for a transaction event.
+
+    Parameters
+    ----------
+    event: mapping conforming to the event schema
+    correlation_id: optional ID used to correlate logs across services
+    """
+    correlation_id = correlation_id or str(uuid.uuid4())
+    reasons = []
+    tx = event.get("transaction", {})
+    features = event.get("features", {})
+
+    amount = tx.get("amount", 0)
+    if amount > 1000:
+        reasons.append("amount_gt_1000")
+
+    if features.get("velocity_score", 0) > 0.8:
+        reasons.append("velocity_score_high")
+
+    if features.get("is_high_risk_country"):
+        reasons.append("high_risk_country")
+
+    is_fraud = bool(reasons)
+    score = min(1.0, len(reasons) / 3)
+    decision = {"fraud": is_fraud, "score": score, "reasons": reasons}
+
+    _log({"event_id": event.get("event_id"), "decision": decision}, correlation_id)
+    return decision

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -1,0 +1,29 @@
+import sys
+import pathlib
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from fraud_detector import evaluate_transaction
+
+def _base_event(**overrides):
+    event = {
+        "event_id": "1",
+        "transaction": {"amount": 50},
+        "features": {"velocity_score": 0.1, "is_high_risk_country": False},
+    }
+    for key, value in overrides.items():
+        if key in event and isinstance(event[key], dict):
+            event[key].update(value)
+        else:
+            event[key] = value
+    return event
+
+def test_high_amount_flagged():
+    event = _base_event(transaction={"amount": 2000})
+    decision = evaluate_transaction(event)
+    assert decision["fraud"]
+    assert "amount_gt_1000" in decision["reasons"]
+
+def test_clean_transaction_passes():
+    event = _base_event()
+    decision = evaluate_transaction(event)
+    assert decision == {"fraud": False, "score": 0.0, "reasons": []}


### PR DESCRIPTION
## Summary
- add `fraud_detector` module providing simple rule-based evaluation and JSON logs with correlation IDs
- cover new detector with unit tests
- document running tests and add gitleaks config to ignore virtual env

## Testing
- `pytest`
- `pip-audit -r requirements.txt`
- `gitleaks detect --source . --no-git`


------
https://chatgpt.com/codex/tasks/task_e_689d8b1785a88322928fd48a196e42f0