### PR TITLE
fix: add GITHUB_TOKEN to gitleaks

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -25,4 +25,5 @@ jobs:
       - name: Scan for secrets with gitleaks
         uses: gitleaks/gitleaks-action@v2
         with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           args: detect --source . --no-git -v


### PR DESCRIPTION
## Summary
- provide GITHUB_TOKEN to gitleaks action

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d9047b9888322a9afdb8e50980294