### PR TITLE
Validate incoming events against schema

### DIFF
--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -1,5 +1,9 @@
 import sys
 import pathlib
+
+import jsonschema
+import pytest
+
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
 from fraud_detector import evaluate_transaction
@@ -7,11 +11,19 @@ from fraud_detector import evaluate_transaction
 def _base_event(**overrides):
     event = {
         "event_id": "1",
-        "transaction": {"amount": 50},
+        "event_time": "2024-01-01T00:00:00Z",
+        "transaction": {
+            "transaction_id": "tx1",
+            "account_id": "acct1",
+            "timestamp": "2024-01-01T00:00:00Z",
+            "amount": 50,
+            "currency": "USD",
+            "status": "authorised",
+        },
         "features": {"velocity_score": 0.1, "is_high_risk_country": False},
     }
     for key, value in overrides.items():
-        if key in event and isinstance(event[key], dict):
+        if key in event and isinstance(event[key], dict) and isinstance(value, dict):
             event[key].update(value)
         else:
             event[key] = value
@@ -27,3 +39,10 @@ def test_clean_transaction_passes():
     event = _base_event()
     decision = evaluate_transaction(event)
     assert decision == {"fraud": False, "score": 0.0, "reasons": []}
+
+
+def test_invalid_event_raises():
+    event = _base_event()
+    event.pop("transaction")
+    with pytest.raises(jsonschema.ValidationError):
+        evaluate_transaction(event)


### PR DESCRIPTION
## Summary
- load and apply event schema in `evaluate_transaction`
- add unit tests for valid and invalid events

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689dbe26c8988322ac159f2d44c8ba90