### PR TITLE
Disallow unexpected fields in schema

### DIFF
--- a/eventSchema.json
+++ b/eventSchema.json
@@ -44,6 +44,7 @@
     },
     "location": {
       "type": "object",
+      "additionalProperties": false,
       "properties": {
         "lat": { "type": "number", "minimum": -90, "maximum": 90 },
         "lon": { "type": "number", "minimum": -180, "maximum": 180 },

--- a/schemaValidityTest.py
+++ b/schemaValidityTest.py
@@ -17,3 +17,19 @@ def test_valid_events(event):
 def test_invalid_events(event):
     with pytest.raises(jsonschema.ValidationError):
         jsonschema.validate(instance=event, schema=SCHEMA)
+
+
+@pytest.mark.parametrize("path", [
+    ("unexpected",),
+    ("device", "unexpected"),
+    ("location", "unexpected"),
+])
+def test_unexpected_fields(path):
+    event = _load_events("valid*.json")[0]
+    event = json.loads(json.dumps(event))
+    target = event
+    for key in path[:-1]:
+        target = target[key]
+    target[path[-1]] = "extra"
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=event, schema=SCHEMA)


### PR DESCRIPTION
## Summary
- enforce `additionalProperties: false` in `location`
- test that unexpected fields at root, `device`, and `location` are rejected

## Testing
- `pytest -q`
- `pytest schemaValidityTest.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689dc1a3a874832284e15a373c809b6e