### PR TITLE
feat: expose logging configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,16 @@ Work in progress
 ## Fraud detector
 
 A minimal rule-based detector is available in the `fraud_detector` package. The
-`evaluate_transaction` function returns a structured decision and emits JSON logs with a
-correlation ID to aid tracing.
+`evaluate_transaction` function returns a structured decision and emits JSON
+logs with a correlation ID to aid tracing.
+
+### Logging
+
+The module uses a logger named `fraud_detector` that outputs one JSON record per
+line. Call `fraud_detector.configure_logging()` to attach the default
+`StreamHandler`, or pass in a custom logger so applications can manage logging
+themselves. The handler is only added if none are present to avoid duplicate
+logs.
 
 ## Run tests
 

--- a/fraud_detector/__init__.py
+++ b/fraud_detector/__init__.py
@@ -1,3 +1,3 @@
-from .fraud_detector import evaluate_transaction, _RULES
+from .fraud_detector import evaluate_transaction, configure_logging, _RULES
 
-__all__ = ["evaluate_transaction", "_RULES"]
+__all__ = ["evaluate_transaction", "configure_logging", "_RULES"]

--- a/fraud_detector/fraud_detector.py
+++ b/fraud_detector/fraud_detector.py
@@ -1,3 +1,10 @@
+"""Simple rule-based fraud detection with JSON logging.
+
+The module exposes :func:`configure_logging` to allow applications to manage
+the logger used for JSON output. A default logger named ``fraud_detector`` is
+configured to emit one JSON record per line to ``stdout``.
+"""
+
 import json
 import logging
 import uuid
@@ -7,10 +14,38 @@ from typing import Dict, Any, Callable, Tuple, List
 import jsonschema
 
 logger = logging.getLogger("fraud_detector")
-_handler = logging.StreamHandler()
-_handler.setFormatter(logging.Formatter('%(message)s'))
-logger.addHandler(_handler)
-logger.setLevel(logging.INFO)
+
+
+def configure_logging(
+    external_logger: logging.Logger | None = None,
+    level: int = logging.INFO,
+) -> logging.Logger:
+    """Configure the module logger.
+
+    Parameters
+    ----------
+    external_logger:
+        Optional logger instance to use instead of the default one.
+    level:
+        Logging level applied to the logger.
+
+    Returns
+    -------
+    logging.Logger
+        The configured logger instance.
+    """
+    global logger
+    if external_logger is not None:
+        logger = external_logger
+    if not logger.handlers:
+        handler = logging.StreamHandler()
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        logger.addHandler(handler)
+    logger.setLevel(level)
+    return logger
+
+
+configure_logging()
 
 with open(Path(__file__).with_name("eventSchema.json")) as _f:
     _EVENT_SCHEMA = json.load(_f)

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -6,7 +6,7 @@ import jsonschema
 import pytest
 
 import fraud_detector
-from fraud_detector import evaluate_transaction
+from fraud_detector import evaluate_transaction, configure_logging
 
 def _base_event(**overrides):
     event = {
@@ -78,3 +78,15 @@ def test_invalid_correlation_id_replaced(caplog, monkeypatch):
         evaluate_transaction(event, correlation_id="not-a-uuid")
     record = caplog.records[-1]
     assert json.loads(record.message)["correlation_id"] == new_cid
+
+
+def test_configure_logging_custom_logger():
+    custom = logging.getLogger("custom")
+    custom.handlers.clear()
+    configure_logging(custom)
+    assert fraud_detector.fraud_detector.logger is custom
+    before = len(custom.handlers)
+    configure_logging(custom)
+    assert len(custom.handlers) == before
+    custom.handlers.clear()
+    configure_logging(logging.getLogger("fraud_detector"))


### PR DESCRIPTION
## Summary
- add `configure_logging` helper and avoid duplicate log handlers
- document logging setup in code and README
- test custom logger configuration

## Testing
- `python -m pytest`
- `pip-audit -r requirements.txt`
- `gitleaks detect --source . --no-git`

------
https://chatgpt.com/codex/tasks/task_e_689fa334628c8322b30696a5ad1ffb9d