### PR TITLE
Refactor rule management for extensibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ A minimal rule-based detector is available in the `fraud_detector` package. The
 `evaluate_transaction` function returns a structured decision and emits JSON
 logs with a correlation ID to aid tracing.
 
+Rules are registered in a central registry so each can be tested in isolation.
+Additional rule modules can be loaded by setting the `FRAUD_RULE_MODULES`
+environment variable to a comma-separated list of module paths. Each module
+should register rules using the provided decorator.
+
 ### Logging
 
 The module uses a logger named `fraud_detector` that outputs one JSON record per

--- a/fraud_detector/__init__.py
+++ b/fraud_detector/__init__.py
@@ -1,3 +1,4 @@
-from .fraud_detector import evaluate_transaction, configure_logging, _RULES
+from .fraud_detector import evaluate_transaction, configure_logging
+from .rule_registry import rules_registry
 
-__all__ = ["evaluate_transaction", "configure_logging", "_RULES"]
+__all__ = ["evaluate_transaction", "configure_logging", "rules_registry"]

--- a/fraud_detector/rule_registry.py
+++ b/fraud_detector/rule_registry.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from importlib import import_module
+import os
+from typing import Callable, Dict, Any, Iterator, List, Tuple, Sequence
+
+Rule = Callable[[Dict[str, Any], Dict[str, Any]], bool]
+RuleEntry = Tuple[str, Rule]
+
+
+class RuleRegistry:
+    """Registry for fraud detection rules."""
+
+    def __init__(self) -> None:
+        self._rules: List[RuleEntry] = []
+
+    def register(self, name: str | None = None) -> Callable[[Rule], Rule]:
+        """Decorator to register a rule function.
+
+        Parameters
+        ----------
+        name: optional explicit rule name. Defaults to the function's ``__name__``.
+        """
+
+        def decorator(func: Rule) -> Rule:
+            rule_name = name or func.__name__
+            self._rules.append((rule_name, func))
+            return func
+
+        return decorator
+
+    def __iter__(self) -> Iterator[RuleEntry]:  # pragma: no cover - simple iteration
+        return iter(self._rules)
+
+    def __len__(self) -> int:  # pragma: no cover - trivial
+        return len(self._rules)
+
+    def load_modules(self, modules: Sequence[str]) -> None:
+        """Import modules that register additional rules."""
+        for module in modules:
+            import_module(module)
+
+    def load_from_env(self, env_var: str = "FRAUD_RULE_MODULES") -> None:
+        """Load rule modules listed in the ``env_var`` environment variable."""
+        modules = os.environ.get(env_var)
+        if modules:
+            self.load_modules([m.strip() for m in modules.split(",") if m.strip()])
+
+
+rules_registry = RuleRegistry()

--- a/fraud_detector/rules.py
+++ b/fraud_detector/rules.py
@@ -1,0 +1,24 @@
+"""Built-in fraud detection rules."""
+from __future__ import annotations
+
+from typing import Dict, Any
+
+from .rule_registry import rules_registry
+
+
+@rules_registry.register()
+def amount_gt_1000(tx: Dict[str, Any], feats: Dict[str, Any]) -> bool:
+    """Flag transactions where the amount exceeds $1000."""
+    return tx.get("amount", 0) > 1000
+
+
+@rules_registry.register()
+def velocity_score_high(tx: Dict[str, Any], feats: Dict[str, Any]) -> bool:
+    """Flag when the velocity score feature is above 0.8."""
+    return feats.get("velocity_score", 0) > 0.8
+
+
+@rules_registry.register()
+def high_risk_country(tx: Dict[str, Any], feats: Dict[str, Any]) -> bool:
+    """Flag transactions originating from high risk countries."""
+    return bool(feats.get("is_high_risk_country"))

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -1,10 +1,13 @@
 import json
 import logging
 import uuid
+import pathlib
+import sys
 
 import jsonschema
 import pytest
 
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 import fraud_detector
 from fraud_detector import evaluate_transaction, configure_logging
 
@@ -34,7 +37,7 @@ def test_high_amount_flagged():
     decision = evaluate_transaction(event)
     assert decision["fraud"]
     assert "amount_gt_1000" in decision["reasons"]
-    expected = len(decision["reasons"]) / len(fraud_detector._RULES)
+    expected = len(decision["reasons"]) / len(fraud_detector.rules_registry)
     assert decision["score"] == pytest.approx(expected)
 
 def test_clean_transaction_passes():
@@ -57,7 +60,7 @@ def test_multiple_flags_scaled_score():
     )
     decision = evaluate_transaction(event)
     assert len(decision["reasons"]) == 2
-    expected = len(decision["reasons"]) / len(fraud_detector._RULES)
+    expected = len(decision["reasons"]) / len(fraud_detector.rules_registry)
     assert decision["score"] == pytest.approx(expected)
 
 


### PR DESCRIPTION
## Summary
- introduce a pluggable `RuleRegistry` with decorator-based rule registration
- replace hard-coded `_RULES` with named functions and dynamic rule counting
- document and expose environment-variable loading of external rule modules

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689fa48ba784832290d95f22f4743b5b